### PR TITLE
fix: handle FAILED end states correctly

### DIFF
--- a/lib/cfn-events.js
+++ b/lib/cfn-events.js
@@ -58,9 +58,9 @@ async function * streamStackEvents (
           break
         }
 
-        // If the stack resource is in COMPLETE state, assume the stack operation
+        // If the stack resource is in COMPLETE or FAILED state, assume the stack operation
         // has concluded.
-        complete = complete || /_COMPLETE$/.test(event.ResourceStatus)
+        complete = complete || /_COMPLETE|_FAILED$/.test(event.ResourceStatus)
       }
     }
 

--- a/test/mock-cfn-events.js
+++ b/test/mock-cfn-events.js
@@ -194,6 +194,63 @@ const SampleStackEventsPerPollingRoundWithCleanup = [
   ]
 ]
 
+const SampleStackEventsDeleteFailedState = [
+  [
+    {
+      ResourceType: 'AWS::CloudFormation::Stack',
+      LogicalResourceId: 'test-stack',
+      PhysicalResourceId: 'test-stack-id',
+      ResourceStatus: 'DELETE_FAILED',
+      StackId: 'test-stack-id',
+      StackName: 'test-stack',
+      Timestamp: new Date(),
+      EventId: '0005'
+    },
+    {
+      ResourceType: 'AWS::S3::Bucket',
+      LogicalResourceId: 'Bucket',
+      PhysicalResourceId: 'test-bucket-igivftgohq4l',
+      ResourceStatus: 'DELETE_FAILED',
+      ResourceStatusReason: 'Resource handler returned message: "The bucket you tried to delete is not empty (Service: S3, Status Code: 409, Request ID: J4BPF9MYZP36KZZH, Extended Request ID: 824TafEaWLY3RO8AbKUMQGxcAIZmL0++mj+YgjdOro7OBaqV2thjjJ7KJMub22CaQ/1yG+g6PYo=)" (RequestToken: 65009dd2-331d-4476-04b2-838fcc5930ec, HandlerErrorCode: GeneralServiceException)',
+      StackId: 'test-stack-id',
+      StackName: 'test-stack',
+      Timestamp: new Date(),
+      EventId: '0004'
+    },
+    {
+      ResourceType: 'AWS::S3::Bucket',
+      LogicalResourceId: 'Bucket',
+      PhysicalResourceId: 'test-bucket-igivftgohq4l',
+      ResourceStatus: 'DELETE_IN_PROGRESS',
+      StackId: 'test-stack-id',
+      StackName: 'test-stack',
+      Timestamp: new Date(),
+      EventId: '0003'
+    },
+    {
+      ResourceType: 'AWS::CloudFormation::Stack',
+      LogicalResourceId: 'test-stack',
+      PhysicalResourceId: 'test-stack-id',
+      ResourceStatus: 'DELETE_IN_PROGRESS',
+      ResourceStatusReason: 'User Initiated',
+      StackId: 'test-stack-id',
+      StackName: 'test-stack',
+      Timestamp: new Date(),
+      EventId: '0002'
+    },
+    {
+      ResourceType: 'AWS::CloudFormation::Stack',
+      LogicalResourceId: 'test-stack',
+      PhysicalResourceId: 'test-stack-id',
+      ResourceStatus: 'CREATE_COMPLETE',
+      StackId: 'test-stack-id',
+      StackName: 'test-stack',
+      Timestamp: new Date(),
+      EventId: '0001'
+    }
+  ]
+]
+
 /**
  * Mock DescribeStackEvents to yield certain events after each
  * polling round.
@@ -309,6 +366,7 @@ module.exports = {
   SampleStackEventsPerPollingRound,
   SampleStackEventsPerPollingRoundSimple,
   SampleStackEventsPerPollingRoundWithCleanup,
+  SampleStackEventsDeleteFailedState,
   deleteStackEvents,
   updateStackEvents
 }

--- a/test/test_cfn-events.js
+++ b/test/test_cfn-events.js
@@ -93,4 +93,25 @@ describe('cfn-events', function () {
       '0006'
     ])
   })
+
+  it('should handle FAILED end state correctly', async function () {
+    cfMock
+      .on(DescribeStackEventsCommand, {
+        StackName: 'test-stack-id'
+      })
+      .callsFake(mockCfnEvents.mockDescribeStackEvents(mockCfnEvents.SampleStackEventsDeleteFailedState))
+    const events = await utils.asyncGeneratorToArray(
+      cfnEvents.streamStackEvents(
+        'test-stack',
+        'test-stack-id',
+        'eu-north-1'
+      )
+    )
+    expect(events.map((e) => e.EventId)).to.deep.equal([
+      '0002',
+      '0003',
+      '0004',
+      '0005'
+    ])
+  })
 })


### PR DESCRIPTION
Previously stack had to go to a _COMPLETED state for monitoring to end. However, stack operation can also end in various _FAILED states. This commit adds handling for those states to have the tool stop monitoring a stack when the stack update has failed.

Fixes #201.